### PR TITLE
Fixing "uninitialized constant Fluent::TextParser" in fluentd 0.14

### DIFF
--- a/lib/fluent/plugin/out_burrow.rb
+++ b/lib/fluent/plugin/out_burrow.rb
@@ -5,6 +5,8 @@
 # format, and then re-emit a new event with the key's value replaced, or with the whole record replaced.
 #
 
+require 'fluent/parser'
+
 class Fluent::BurrowPlugin < Fluent::Output
   # Register type
   Fluent::Plugin.register_output('burrow', self)
@@ -140,7 +142,7 @@ class Fluent::BurrowPlugin < Fluent::Output
 
       # Emit event back to Fluent
       if r
-        Fluent::Engine.emit(tag, t, r)
+        router.emit(tag, t, r)
       end
     end
 


### PR DESCRIPTION
In fluentd version 0.14 get the following error:

```
2016-09-30 21:20:46 +0000 [error]: fluent/supervisor.rb:620:rescue in main_process: unexpected error error="uninitialized constant Fluent::TextParser"
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluent-plugin-burrow-1.1/lib/fluent/plugin/out_burrow.rb:70:in `configure'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/agent.rb:135:in `add_match'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/agent.rb:69:in `block in configure'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/agent.rb:63:in `each'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/agent.rb:63:in `configure'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/root_agent.rb:86:in `configure'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/engine.rb:119:in `configure'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/engine.rb:93:in `run_configure'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/supervisor.rb:673:in `run_configure'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/supervisor.rb:435:in `block in run_worker'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/supervisor.rb:606:in `main_process'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/supervisor.rb:431:in `run_worker'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/lib/fluent/command/fluentd.rb:271:in `<top (required)>'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:55:in `require'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:55:in `require'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/fluentd-0.14.4/bin/fluentd:5:in `<top (required)>'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/bin/fluentd:22:in `load'
  2016-09-30 21:20:46 +0000 [error]: command/fluentd.rb:271:<top (required)>: /opt/rh/rh-ruby23/root/usr/local/bin/fluentd:22:in `<main>'
```

Fixing with `require 'fluent/parser'`

Also fixing error where `router.emit` should be used now instead of `Fluent::Engine.emit`. 

Tested successfully with versions 0.12.29 and 0.14.4.
